### PR TITLE
[platformAutomerge 不能なため closed] Enable automerging for `devDependencies`' minor updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,22 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "timezone": "Asia/Tokyo",
+  "packageRules": [
+    {
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    }
   ]
 }


### PR DESCRIPTION
# 概要

参考：https://github.com/private-yusuke/botot2/pull/96

`devDependencies` については automerging を有効にし、Renovate による自動的な依存関係のアップデートを有効にします。
（たくさん PR が溜まってしまっていることに今気づいたのでこれを改善したい）

## 動作確認

`npx --package renovate -c renovate-config-validator` で正当な config になっていることを検証しました