### PR TITLE
Enable automerging for `devDependencies`' minor updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,8 +16,7 @@
         "digest"
       ],
       "automerge": true,
-      "automergeType": "pr",
-      "platformAutomerge": true
+      "automergeType": "pr"
     }
   ]
 }


### PR DESCRIPTION
# 概要

ref: #22

`devDependencies` については automerging を有効にし、Renovate による自動的な依存関係のアップデートを有効にします。
（たくさん PR が溜まってしまっていることに今気づいたのでこれを改善したい）

`platformAutomerge` は GitHub のプランの関係上利用できないので使いません[^1]。

## 動作確認

`npx --package renovate -c renovate-config-validator` で正当な config になっていることを検証しました

[^1]: https://github.com/sapakan/sapakan/pull/22#issuecomment-1491936963