### PR TITLE
Enable automerging for patch releases of `@swc/core`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,18 @@
       ],
       "automerge": true,
       "automergeType": "pr"
+    },
+    {
+      "matchPackageNames": [
+        "@swc/core"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "automerge": true,
+      "automergeType": "pr"
     }
   ]
 }


### PR DESCRIPTION
# 概要

ref: https://github.com/sapakan/sapakan/pull/39#issuecomment-1501715797

`@swc/core` の patch リリースの頻度が高いため、patch リリース以下については automerging を有効にします。

## 動作確認

`npx --package renovate -c renovate-config-validator` で正当な config になっていることを検証しました