### PR TITLE
Require authenticated in `POST /posts/:id/likes`

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -33,7 +33,7 @@ app.get("/", homeController.index);
 app.post("/posts", ensureLoggedIn, postsController.postPosts);
 app.get("/posts/:id", postsController.getPost);
 app.get("/posts/:id/likes", postsController.getPostLikes);
-app.post("/posts/:id/likes", postsController.postPostLikes);
+app.post("/posts/:id/likes", ensureLoggedIn, postsController.postPostLikes);
 app.delete("/posts/:id/likes", postsController.deletePostLikes);
 app.get("/accounts/:id", accountsController.getAccount);
 app.get("/accounts/:id/posts", accountsController.getAccountPosts);

--- a/src/controllers/posts.ts
+++ b/src/controllers/posts.ts
@@ -2,6 +2,7 @@ import { Response, Request } from "express";
 import prisma from "../lib/prisma";
 import { createLike, deleteLike } from "../services/create-like";
 import { createPost } from "../services/create-post";
+import assert from "assert";
 
 /**
  * POST /posts
@@ -133,8 +134,9 @@ export const postPostLikes = async (req: Request, res: Response) => {
     return res.status(400).json({ message: "id is not an integer" });
   }
 
-  // TODO: 現時点でアカウントの認証がないので、id = 1 のアカウントとして振る舞わせているのを解消する
-  const likedById = 1;
+  const likedById = req.user?.accountId;
+  // 前段に ensureLoggedIn があるためここの likedById が undefined になることはない
+  assert(likedById !== undefined);
 
   // Like を付ける対象の投稿が存在しないならば 404 を返す
   if (!(await postExists(postId))) {


### PR DESCRIPTION
# 概要

ref: #7

- `POST /posts/:id/likes` で `likedById` をリクエストに含めるのをやめ、現在認証されているユーザーが投稿したことにするように動作を変更します
- また、未ログイン時にこのエンドポイントを利用している場合はリダイレクトがかかることをテストで検証するようにします

## レビューしてほしいところ

- `POST /posts/:id/likes` から `likedById` を受け取るような箇所が消えたこと。また、テスト用のリクエストで `likedById` を送信しなくなったこと

テストが通ったらマージしてしまいます。