### PR TITLE
Fix flaky test for timeline

### DIFF
--- a/test/requests/timeline.test.ts
+++ b/test/requests/timeline.test.ts
@@ -12,9 +12,14 @@ describe("GET /timeline", () => {
     const followingAccount = await followingFactory.create({
       followerId: me.id,
     });
-    const postsByfollowingAccount = await postFactory.createList(2, {
-      authorId: followingAccount.followeeId,
-    });
+    const postsByfollowingAccount = [
+      await postFactory.create({
+        authorId: followingAccount.followeeId,
+      }),
+      await postFactory.create({
+        authorId: followingAccount.followeeId,
+      }),
+    ];
 
     // 0 番目の投稿だけ自身が like している
     await likeFactory.create({


### PR DESCRIPTION
# 概要

closes #72 

当該テストコードで 2 つの Post を作成する箇所で利用している関数 `postFactory.createList` の実装を見てみると、これは `postFactory.create` で返される Promise を引数で指定された回数だけ取得して最後に `Promise.all` で囲っているだけであり[^1]、これでは Post が作成される順番は deterministic になりません。すなわち、「添字 0 の Post」が「添字 1 の Post」より必ずしも先に作成されるとは限りません。

そこで、当該箇所で `postFactory.createList` を呼び出すのをやめ、かわりにそれぞれの Post を生成するときには `postFactory.create` を呼び出して帰ってきた Promise を await してから次の Post を生成するようにします。

[^1]: https://github.com/thoughtbot/fishery/blob/2bd552c8185bfce29c90faa09dd2a576e6282663/lib/factory.ts#L78C3-L89

## 動作確認

手元で 5 回ほどテストを走らせてすべて成功すること