### PR TITLE
Validate HTTP requests sent with signature

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -4,6 +4,10 @@ declare global {
       accountId: number;
       username: string;
     }
+
+    interface Request {
+      rawBody: Buffer;
+    }
   }
 }
 export default global;

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import * as nodeInfoController from "./controllers/nodeinfo";
 import * as webFingerController from "./controllers/webfinger";
 import passport from "passport";
 import { ensureLoggedIn } from "./lib/middlewares";
+import * as http from "http";
 
 const app = express()
   .use(
@@ -35,6 +36,13 @@ app.use(bodyParser.json());
 app.use(
   bodyParser.json({
     type: "application/activity+json",
+    verify(req: http.IncomingMessage, res: http.ServerResponse, buf: Buffer) {
+      // verify を async function にすることはできないため Express のハンドラ側で署名を検証する
+      // TODO: http.IncomingMessage に rawBody プロパティを追加する
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      req.rawBody = buf;
+    },
   })
 );
 app.use(bodyParser.urlencoded({ extended: true }));

--- a/src/controllers/accounts.ts
+++ b/src/controllers/accounts.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import prisma from "../lib/prisma";
 import type { Activity, Person } from "../@types/activitystreams";
 import { config } from "../config";
+import { validateHttpRequest } from "../lib/validate-http-request";
 
 /**
  * GET /accounts/:username
@@ -164,6 +165,13 @@ export const postAccountInbox = async (req: Request, res: Response) => {
   const account = await prisma.account.findUnique({ where: { username } });
   if (account === null) {
     return res.status(404).json({ message: "Account not found" });
+  }
+
+  const valid = await validateHttpRequest(req, req.rawBody);
+  if (!valid) {
+    return res
+      .status(400)
+      .json({ message: "request with invalid signature and/or digest" });
   }
 
   // TODO: フォローの実装ができたら以下のデバッグ出力を削除する

--- a/src/lib/validate-http-request.ts
+++ b/src/lib/validate-http-request.ts
@@ -1,0 +1,173 @@
+import crypto from "crypto";
+import * as http from "http";
+import assert from "assert";
+
+type ValidateSignatureOptions = {
+  publicKey?: string;
+};
+
+/**
+ * 与えられた HTTP リクエストに付与されている署名と Digest が正しいならば true を、そうでなければ false を返します。
+ * ただし、署名または Digest が付与されていない場合は false を返します。
+ */
+export async function validateHttpRequest(
+  req: http.IncomingMessage,
+  reqBody: Buffer,
+  options: ValidateSignatureOptions = {}
+): Promise<boolean> {
+  const digest = req.headers.digest;
+  if (digest === undefined || typeof digest === "object") {
+    return false;
+  }
+  if (!validateDigest(digest, reqBody)) {
+    return false;
+  }
+
+  return await validateSignature(req, options);
+}
+
+/**
+ * 与えられた Digest が正しいならば true を、そうでなければ false を返します。
+ */
+export function validateDigest(
+  digestHeaderValue: string,
+  reqBody: Buffer
+): boolean {
+  // SHA-256 で始まる署名のみをサポートする
+  if (!digestHeaderValue.startsWith("SHA-256=")) {
+    return false;
+  }
+
+  const expected = digestHeaderValue.slice(8);
+
+  const hash = crypto.createHash("sha256");
+  hash.update(reqBody);
+  const actual = hash.digest("base64");
+
+  return expected === actual;
+}
+
+/**
+ * 与えられた HTTP リクエストに付与されている署名が正しいならば true を、そうでなければ false を返します。
+ * algorithm は rsa-sha256 のみをサポートします。
+ */
+async function validateSignature(
+  req: http.IncomingMessage,
+  options: ValidateSignatureOptions = {}
+): Promise<boolean> {
+  const signatureHeaderValue = req.headers.signature;
+  if (
+    signatureHeaderValue === undefined ||
+    typeof signatureHeaderValue === "object"
+  ) {
+    return false;
+  }
+
+  const signatureMap = translateToSignatureFields(signatureHeaderValue);
+  const keyId = signatureMap.get("keyId");
+  if (keyId === undefined) {
+    return false;
+  }
+
+  const algorithm = signatureMap.get("algorithm");
+  if (algorithm === undefined) {
+    return false;
+  }
+  if (algorithm !== "rsa-sha256") {
+    return false;
+  }
+
+  const signature = signatureMap.get("signature");
+  if (signature === undefined) {
+    return false;
+  }
+
+  const headers = signatureMap.get("headers");
+  if (headers === undefined) {
+    return false;
+  }
+
+  const signedHeaders = headers.split(" ");
+  const signedString = buildSignedString(req, signedHeaders);
+
+  let publicKey = options.publicKey;
+  if (publicKey === undefined) {
+    const fetchedPublicKey = await fetchPublicKey(keyId);
+    if (fetchedPublicKey === null) {
+      return false;
+    }
+    publicKey = fetchedPublicKey;
+  }
+
+  const verifier = crypto.createVerify("sha256");
+  verifier.update(signedString);
+  return verifier.verify(publicKey, signature, "base64");
+}
+
+/**
+ * Signature ヘッダーに格納されているキーバリューのマップを返します。
+ */
+function translateToSignatureFields(
+  signatureHeaderValue: string
+): Map<string, string> {
+  return (
+    signatureHeaderValue
+      .split(",")
+      .map((pair) => pair.split("="))
+      // 2つ以上の "=" が含まれる可能性があるので、先頭の要素をキー、残りを値として扱う
+      .map((array) => [array[0], array.slice(1).join("=")])
+      .reduce((map, [key, value]) => map.set(key, JSON.parse(value)), new Map())
+  );
+}
+
+/**
+ * 与えられた HTTP リクエストに付与されている署名の対象となることが期待される文字列を返します。
+ */
+function buildSignedString(
+  req: http.IncomingMessage,
+  signedHeaders: string[]
+): string {
+  return signedHeaders
+    .map((signedHeaderKey) => {
+      const headerValue = getHeaderValueWithSignedHeaderKey(
+        req,
+        signedHeaderKey
+      );
+      return `${signedHeaderKey}: ${headerValue}`;
+    })
+    .join("\n");
+}
+
+/**
+ * Signature ヘッダーに指定されている headers に対応するヘッダーの値を返します。
+ */
+function getHeaderValueWithSignedHeaderKey(
+  req: http.IncomingMessage,
+  signedHeaderKey: string
+): string {
+  if (signedHeaderKey === "(request-target)") {
+    assert(req.method !== undefined);
+    return `${req.method.toLowerCase()} ${req.url}`;
+  }
+  return req.headers[signedHeaderKey] as string;
+}
+
+/**
+ * 与えられた keyId に対応する公開鍵を取得して返します。
+ * 取得できなかった場合は null を返します。
+ */
+async function fetchPublicKey(keyId: string): Promise<string | null> {
+  const response = await fetch(keyId, {
+    method: "GET",
+    headers: {
+      Accept: "application/activity+json",
+    },
+  });
+  if (!response.ok) {
+    return null;
+  }
+
+  // TODO: ローカルアカウントが鍵ペアを持つようになったら `Person` の型定義を変更した上で `json` に型を付ける
+  const person = await response.json();
+  return person.publicKey.publicKeyPem;
+}

--- a/test/src-lib/validate-http-request.test.ts
+++ b/test/src-lib/validate-http-request.test.ts
@@ -1,0 +1,106 @@
+import {
+  validateDigest,
+  validateHttpRequest,
+} from "../../src/lib/validate-http-request";
+import httpMocks from "node-mocks-http";
+
+describe(validateDigest, () => {
+  test("digest が正しいとき true を返す", async () => {
+    // Pleroma から送信されたリクエストの一つを再現したもの
+    const REQUEST_BODY = `{"@context":["https://www.w3.org/ns/activitystreams","http://pleroma.local/schemas/litepub-0.1.jsonld",{"@language":"und"}],"actor":"http://pleroma.local/users/foobar","context":"http://pleroma.local/contexts/237271ba-fe4c-418b-af05-0c7d625f01e3","id":"http://pleroma.local/activities/7fc0472e-39d2-4dd6-8ec7-2436bb4ae9c3","object":{"actor":"http://pleroma.local/users/foobar","bcc":[],"bto":[],"cc":[],"context":"http://pleroma.local/contexts/237271ba-fe4c-418b-af05-0c7d625f01e3","id":"http://pleroma.local/activities/96c7bf69-41d9-49b2-a941-167b5dae4e06","object":"http://sapakan.local/accounts/test2","published":"2023-05-30T16:48:42.910881Z","state":"cancelled","to":["http://sapakan.local/accounts/test2"],"type":"Follow"},"published":"2023-05-30T16:48:42.910864Z","to":["http://sapakan.local/accounts/test2"],"type":"Undo"}`;
+    const buffer = Buffer.from(REQUEST_BODY);
+
+    const req = httpMocks.createRequest({
+      method: "POST",
+      url: "/accounts/test2/inbox",
+      headers: {
+        host: "sapakan.local",
+        date: "Tue, 30 May 2023 16:48:42 GMT",
+        signature: `keyId="http://pleroma.local/users/foobar#main-key",algorithm="rsa-sha256",headers="(request-target) content-length date digest host",signature="LAC7/pVvsu8uHWJJiX+RrKDGVv5gVE1Mo13WvnnZYScRUnzLWL6yLpYXsWJe/3VVfB5ohW3zYeSS0zmk744U3zwYMEwpEBCuZ8x1sd0wUeBn7SQcj2M8yQSRVLU9KW0aaTFJjCTFILZaWaYIQUUja4uZ+8OIPhWmgMRO+c3ym+BaD3LMxFlvP0uLROLCvXOGq6PDbKJxQx9etRBY1dSDSD8LO1h1RexlRIRii61lpSAUZ4QOUaltqXMedWVem8096U70xzCDJv5d8s7r7zWC3UGmvkQ4rA+8UqD0/RP2J9PxGURlJrvLvv04QuBb4PB/oNvI098YyJPnngF2SvkPZg=="`,
+        "content-length": "830",
+        digest: "SHA-256=D/gTKeuUJnlOku1R3owOw9VhzftxA2w2gAcnsEM5o4g=",
+      },
+    });
+    req.body = buffer;
+
+    expect(
+      validateDigest(
+        "SHA-256=D/gTKeuUJnlOku1R3owOw9VhzftxA2w2gAcnsEM5o4g=",
+        buffer
+      )
+    ).toBe(true);
+  });
+
+  test("digest が正しくないとき false を返す", async () => {
+    const REQUEST_BODY = `unexpected_content`;
+    const buffer = Buffer.from(REQUEST_BODY);
+
+    const req = httpMocks.createRequest({
+      method: "POST",
+      url: "/accounts/test2/inbox",
+      headers: {
+        host: "sapakan.local",
+        date: "Tue, 30 May 2023 16:48:42 GMT",
+        signature: `keyId="http://pleroma.local/users/foobar#main-key",algorithm="rsa-sha256",headers="(request-target) content-length date digest host",signature="LAC7/pVvsu8uHWJJiX+RrKDGVv5gVE1Mo13WvnnZYScRUnzLWL6yLpYXsWJe/3VVfB5ohW3zYeSS0zmk744U3zwYMEwpEBCuZ8x1sd0wUeBn7SQcj2M8yQSRVLU9KW0aaTFJjCTFILZaWaYIQUUja4uZ+8OIPhWmgMRO+c3ym+BaD3LMxFlvP0uLROLCvXOGq6PDbKJxQx9etRBY1dSDSD8LO1h1RexlRIRii61lpSAUZ4QOUaltqXMedWVem8096U70xzCDJv5d8s7r7zWC3UGmvkQ4rA+8UqD0/RP2J9PxGURlJrvLvv04QuBb4PB/oNvI098YyJPnngF2SvkPZg=="`,
+        "content-length": "830",
+        digest: "SHA-256=D/gTKeuUJnlOku1R3owOw9VhzftxA2w2gAcnsEM5o4g=",
+      },
+    });
+    req.body = buffer;
+
+    expect(
+      validateDigest(
+        "SHA-256=D/gTKeuUJnlOku1R3owOw9VhzftxA2w2gAcnsEM5o4g=",
+        buffer
+      )
+    ).toBe(false);
+  });
+});
+
+describe(validateHttpRequest, () => {
+  test("リクエストが正しいとき true を返す", async () => {
+    const REQUEST_BODY = `{"@context":["https://www.w3.org/ns/activitystreams","http://pleroma.local/schemas/litepub-0.1.jsonld",{"@language":"und"}],"actor":"http://pleroma.local/users/foobar","context":"http://pleroma.local/contexts/237271ba-fe4c-418b-af05-0c7d625f01e3","id":"http://pleroma.local/activities/7fc0472e-39d2-4dd6-8ec7-2436bb4ae9c3","object":{"actor":"http://pleroma.local/users/foobar","bcc":[],"bto":[],"cc":[],"context":"http://pleroma.local/contexts/237271ba-fe4c-418b-af05-0c7d625f01e3","id":"http://pleroma.local/activities/96c7bf69-41d9-49b2-a941-167b5dae4e06","object":"http://sapakan.local/accounts/test2","published":"2023-05-30T16:48:42.910881Z","state":"cancelled","to":["http://sapakan.local/accounts/test2"],"type":"Follow"},"published":"2023-05-30T16:48:42.910864Z","to":["http://sapakan.local/accounts/test2"],"type":"Undo"}`;
+    const buffer = Buffer.from(REQUEST_BODY);
+
+    const req = httpMocks.createRequest({
+      method: "POST",
+      url: "/accounts/test2/inbox",
+      headers: {
+        host: "sapakan.local",
+        date: "Tue, 30 May 2023 16:48:42 GMT",
+        signature: `keyId="http://pleroma.local/users/foobar#main-key",algorithm="rsa-sha256",headers="(request-target) content-length date digest host",signature="LAC7/pVvsu8uHWJJiX+RrKDGVv5gVE1Mo13WvnnZYScRUnzLWL6yLpYXsWJe/3VVfB5ohW3zYeSS0zmk744U3zwYMEwpEBCuZ8x1sd0wUeBn7SQcj2M8yQSRVLU9KW0aaTFJjCTFILZaWaYIQUUja4uZ+8OIPhWmgMRO+c3ym+BaD3LMxFlvP0uLROLCvXOGq6PDbKJxQx9etRBY1dSDSD8LO1h1RexlRIRii61lpSAUZ4QOUaltqXMedWVem8096U70xzCDJv5d8s7r7zWC3UGmvkQ4rA+8UqD0/RP2J9PxGURlJrvLvv04QuBb4PB/oNvI098YyJPnngF2SvkPZg=="`,
+        "content-length": "830",
+        digest: "SHA-256=D/gTKeuUJnlOku1R3owOw9VhzftxA2w2gAcnsEM5o4g=",
+      },
+    });
+    req.body = buffer;
+
+    const publicKey =
+      "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo4Qsd+xnvZ3T5cy+D5Yj\nniEyNd6ruKG0S9qwDDWVyJttHe0wyDRpXRAOlqQDlbCRqZy/7IsaS9BBdXytLQT+\nbjTVemGv6iTCRd69jJhk7o83u4CgsHKpMbSc5GbetF97m5zR81yfQwlG5XcW0Gxx\n0yWJ3kqT6HnaZxgkYyqXoyVng4jQn6HNtaylzzd0bC0va4bDGt2rEIlEIKpk/THx\nfMIqOYl63YwTbW/9susiiIg0zT6g+KI7yV2+5DpNROaAXuVwDf2Rm/HzRnaffgB/\nIukH0Y9r3+6xCUgKMX+5k87qDNxeoh5vw4mViajBWWtg4NTty+Qghwb7rlEvKCkY\nwQIDAQAB\n-----END PUBLIC KEY-----\n\n";
+
+    expect(await validateHttpRequest(req, buffer, { publicKey })).toBe(true);
+  });
+
+  test("不正な署名が与えられたとき false を返す", async () => {
+    const REQUEST_BODY = `{"@context":["https://www.w3.org/ns/activitystreams","http://pleroma.local/schemas/litepub-0.1.jsonld",{"@language":"und"}],"actor":"http://pleroma.local/users/foobar","context":"http://pleroma.local/contexts/237271ba-fe4c-418b-af05-0c7d625f01e3","id":"http://pleroma.local/activities/7fc0472e-39d2-4dd6-8ec7-2436bb4ae9c3","object":{"actor":"http://pleroma.local/users/foobar","bcc":[],"bto":[],"cc":[],"context":"http://pleroma.local/contexts/237271ba-fe4c-418b-af05-0c7d625f01e3","id":"http://pleroma.local/activities/96c7bf69-41d9-49b2-a941-167b5dae4e06","object":"http://sapakan.local/accounts/test2","published":"2023-05-30T16:48:42.910881Z","state":"cancelled","to":["http://sapakan.local/accounts/test2"],"type":"Follow"},"published":"2023-05-30T16:48:42.910864Z","to":["http://sapakan.local/accounts/test2"],"type":"Undo"}`;
+    const buffer = Buffer.from(REQUEST_BODY);
+
+    const req = httpMocks.createRequest({
+      method: "POST",
+      url: "/accounts/test2/inbox",
+      headers: {
+        host: "sapakan.local",
+        date: "Tue, 30 May 2023 16:48:42 GMT",
+        signature: `keyId="http://pleroma.local/users/foobar#main-key",algorithm="rsa-sha256",headers="(request-target) content-length date digest host",signature="invalid_signature"`,
+        "content-length": "830",
+        digest: "SHA-256=D/gTKeuUJnlOku1R3owOw9VhzftxA2w2gAcnsEM5o4g=",
+      },
+    });
+    req.body = buffer;
+
+    const publicKey =
+      "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo4Qsd+xnvZ3T5cy+D5Yj\nniEyNd6ruKG0S9qwDDWVyJttHe0wyDRpXRAOlqQDlbCRqZy/7IsaS9BBdXytLQT+\nbjTVemGv6iTCRd69jJhk7o83u4CgsHKpMbSc5GbetF97m5zR81yfQwlG5XcW0Gxx\n0yWJ3kqT6HnaZxgkYyqXoyVng4jQn6HNtaylzzd0bC0va4bDGt2rEIlEIKpk/THx\nfMIqOYl63YwTbW/9susiiIg0zT6g+KI7yV2+5DpNROaAXuVwDf2Rm/HzRnaffgB/\nIukH0Y9r3+6xCUgKMX+5k87qDNxeoh5vw4mViajBWWtg4NTty+Qghwb7rlEvKCkY\nwQIDAQAB\n-----END PUBLIC KEY-----\n\n";
+
+    expect(await validateHttpRequest(req, buffer, { publicKey })).toBe(false);
+  });
+});


### PR DESCRIPTION
# 概要

closes #121 

署名付き HTTP リクエストの検証を実施する関数とそのテストを追加します。
また、inbox に送信されるリクエストに署名が付いていなかった場合には 400 を返すようにします。

## やっていないこと

- https://datatracker.ietf.org/doc/html/draft-richanna-http-message-signatures-00#section-3.3-3 に準拠すること
  - creation time が未来である署名が無効であると判定すること
  - expiration time が過去である署名が無効であると判定すること
- rsa-sha256 以外のアルゴリズムによる署名のサポート
  - 実際の ActivityPub の実装では Misskey, Mastodon, Pleroma 含め rsa-sha256 またはもう一種ぐらいしかサポートしていない様子